### PR TITLE
fix an error of open file flag when open stdin

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 const fs = require('fs');
 const stdout = process.stdout;
 
-const stdinFd = (process.platform === 'win32') ? process.stdin.fd : fs.openSync('/dev/stdin', 'rs');
+const stdinFd = (process.platform === 'win32') ? process.stdin.fd : fs.openSync('/dev/stdin', 'rs+');
 const BUFSIZE = 128;
 const STOPCHAR = " \n,\r";
 


### PR DESCRIPTION
Please see "https://nodejs.org/dist/latest-v18.x/docs/api/fs.html#file-system-flags"

We should use `rs+` to replace `rs`.